### PR TITLE
fix(geolocation): notify result on watchPosition

### DIFF
--- a/dist/ngCordovaMocks.js
+++ b/dist/ngCordovaMocks.js
@@ -1382,7 +1382,7 @@ ngCordovaMocks.factory('$cordovaGeolocation', ['$interval', '$q', function($inte
 											function(position) {
 												self.currentPosition = position;
 												self.locations.push(position);
-												defer.resolve(position);
+												defer.notify(position);
 											},
 											function(error) {
 												defer.reject(error);

--- a/src/geolocation.js
+++ b/src/geolocation.js
@@ -165,7 +165,7 @@ ngCordovaMocks.factory('$cordovaGeolocation', ['$interval', '$q', function($inte
 											function(position) {
 												self.currentPosition = position;
 												self.locations.push(position);
-												defer.resolve(position);
+												defer.notify(position);
 											},
 											function(error) {
 												defer.reject(error);


### PR DESCRIPTION
Hi,

ngCordova’s `$cordovaGeolocation.watchPosition` method uses `defer.notify` instead of `defer.resolve`, since promises shouldn't be resolved more than once. I think your module should too because at the time we need to specify the same callback for the resolve and the notify arguments.

```js
$cordovaGeolocation.watchPosition(onPosition, onError, onPosition);
```